### PR TITLE
Fix typo in link to ghcr.io container

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ dowloaded from [Releases](https://github.com/prql/prql-query/releases/)
 ### Run as a container image (Docker)
 
     docker pull ghcr.io/prql/prql-query:v0.0.11
-    alias pq="docker run --rm -it -v $(pwd):/data -w /data -u $(id -u):$(id -g) ghcr.io.prql/prql-query:v0.0.11"
+    alias pq="docker run --rm -it -v $(pwd):/data -w /data -u $(id -u):$(id -g) ghcr.io/prql/prql-query:v0.0.11"
     pq --help
 
 ### Via Rust toolchain (Cargo)


### PR DESCRIPTION
This (partially) addresses #9 - the `alias` on the README.md page has an error in the URL to the ghcr.io container. Thanks!