### PR TITLE
feat: add --version option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # pq Changelog
 
+## 0.0.15 - UNRELEASED
+
+* Adds --version parameter (#29, @eitsupi)
+
 ## 0.0.14 - 2022-11-09
 
 * Changes backend argument to be an enum.

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,11 @@ type SourcesType = Vec<(String, String)>;
 
 /// pq: query and transform data with PRQL
 #[derive(Parser, Debug)]
+#[clap(
+    name = env!("CARGO_PKG_NAME"),
+    version = env!("CARGO_PKG_VERSION"),
+    about = env!("CARGO_PKG_DESCRIPTION")
+)]
 struct Cli {
     /// The file(s) to read data FROM if given
     #[clap(short, long, value_parser, env = "PQ_FROM")]


### PR DESCRIPTION
before

```sh
$ pq --help
prql-query 
pq: query and transform data with PRQL

USAGE:
    pq [OPTIONS] [QUERY]

ARGS:
    <QUERY>    The PRQL query to be processed if given, otherwise read from stdin [env:
               PQ_QUERY=] [default: -]

OPTIONS:
    -b, --backend <BACKEND>      The backend to use to process the query [env: PQ_BACKEND=]
                                 [default: auto] [possible values: auto, datafusion, duckdb]
    -d, --database <DATABASE>    The database to connect to [env: PQ_DATABASE=]
    -f, --from <FROM>            The file(s) to read data FROM if given [env: PQ_FROM=]
        --format <FORMAT>        The format to use for the output [env: PQ_FORMAT=] [possible
                                 values: csv, json, parquet, table]
    -h, --help                   Print help information
        --no-exec                Only generate SQL without executing it against files
        --sql                    set this to pass a SQL query rather than a PRQL one [env: PQ_SQL=]
    -t, --to <TO>                The file to write TO if given, otherwise stdout [env: PQ_TO=]
                                 [default: -]
    -w, --writer <WRITER>        The Writer to use for writing the output [env: PQ_WRITER=]
                                 [default: arrow] [possible values: arrow, backend]
```

after

```sh
$ pq --help
prql-query 0.0.14
pq: query and transform data with PRQL

USAGE:
    pq [OPTIONS] [QUERY]

ARGS:
    <QUERY>    The PRQL query to be processed if given, otherwise read from stdin [env:
               PQ_QUERY=] [default: -]

OPTIONS:
    -b, --backend <BACKEND>      The backend to use to process the query [env: PQ_BACKEND=]
                                 [default: auto] [possible values: auto, datafusion, duckdb]
    -d, --database <DATABASE>    The database to connect to [env: PQ_DATABASE=]
    -f, --from <FROM>            The file(s) to read data FROM if given [env: PQ_FROM=]
        --format <FORMAT>        The format to use for the output [env: PQ_FORMAT=] [possible
                                 values: csv, json, parquet, table]
    -h, --help                   Print help information
        --no-exec                Only generate SQL without executing it against files
        --sql                    set this to pass a SQL query rather than a PRQL one [env: PQ_SQL=]
    -t, --to <TO>                The file to write TO if given, otherwise stdout [env: PQ_TO=]
                                 [default: -]
    -V, --version                Print version information
    -w, --writer <WRITER>        The Writer to use for writing the output [env: PQ_WRITER=]
                                 [default: arrow] [possible values: arrow, backend]
```

Notes

- Supported PRQL versions should also be displayed, which requires prql-compiler 0.4.2 (PRQL/prql#1604)
- The datafusion version is publicly available and can be easily displayed, but the duckdb version does not seem to be publicly available.